### PR TITLE
feat: add custom retry strategy support

### DIFF
--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -1,5 +1,6 @@
 import { ProviderOptions } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { splitArray } from '../../src/util/split-array';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
@@ -31,6 +32,7 @@ export async function embedMany<VALUE>({
   values,
   maxParallelCalls = Infinity,
   maxRetries: maxRetriesArg,
+  retryStrategy,
   abortSignal,
   headers,
   providerOptions,
@@ -52,6 +54,11 @@ Maximum number of retries per embedding model call. Set to 0 to disable retries.
 @default 2
    */
   maxRetries?: number;
+
+  /**
+Optional retry strategy configuration.
+   */
+  retryStrategy?: RetryStrategy;
 
   /**
 Abort signal.
@@ -83,7 +90,10 @@ Only applicable for HTTP-based providers.
    */
   maxParallelCalls?: number;
 }): Promise<EmbedManyResult<VALUE>> {
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
 
   const baseTelemetryAttributes = getBaseTelemetryAttributes({
     model,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -1,5 +1,6 @@
 import { ProviderOptions } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { assembleOperationName } from '../telemetry/assemble-operation-name';
 import { getBaseTelemetryAttributes } from '../telemetry/get-base-telemetry-attributes';
 import { getTracer } from '../telemetry/get-tracer';
@@ -26,6 +27,7 @@ export async function embed<VALUE>({
   value,
   providerOptions,
   maxRetries: maxRetriesArg,
+  retryStrategy,
   abortSignal,
   headers,
   experimental_telemetry: telemetry,
@@ -46,6 +48,11 @@ Maximum number of retries per embedding model call. Set to 0 to disable retries.
 @default 2
    */
   maxRetries?: number;
+
+  /**
+Optional retry strategy configuration.
+   */
+  retryStrategy?: RetryStrategy;
 
   /**
 Abort signal.
@@ -70,7 +77,10 @@ Only applicable for HTTP-based providers.
    */
   experimental_telemetry?: TelemetrySettings;
 }): Promise<EmbedResult<VALUE>> {
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
 
   const baseTelemetryAttributes = getBaseTelemetryAttributes({
     model,

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -5,6 +5,7 @@ import {
   imageMediaTypeSignatures,
 } from '../../src/util/detect-media-type';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import {
   DefaultGeneratedFile,
   GeneratedFile,
@@ -41,6 +42,7 @@ export async function generateImage({
   seed,
   providerOptions,
   maxRetries: maxRetriesArg,
+  retryStrategy,
   abortSignal,
   headers,
 }: {
@@ -103,6 +105,11 @@ Maximum number of retries per embedding model call. Set to 0 to disable retries.
   maxRetries?: number;
 
   /**
+Optional retry strategy configuration.
+   */
+  retryStrategy?: RetryStrategy;
+
+  /**
 Abort signal.
  */
   abortSignal?: AbortSignal;
@@ -113,7 +120,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<GenerateImageResult> {
-  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
 
   // default to 1 if the model has not specified limits on
   // how many images can be generated in a single call

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -15,6 +15,7 @@ import * as z4 from 'zod/v4';
 import { NoObjectGeneratedError } from '../../src/error/no-object-generated-error';
 import { prepareHeaders } from '../../src/util/prepare-headers';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { extractContentText } from '../generate-text/extract-content-text';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -198,6 +199,11 @@ Default and recommended: 'auto' (best mode for the model).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Optional retry strategy configuration.
+       */
+      retryStrategy?: RetryStrategy;
+
+      /**
   Additional provider-specific options. They are passed through
   to the provider from the AI SDK and enable provider-specific
   functionality that can be fully encapsulated in the provider.
@@ -220,6 +226,7 @@ Default and recommended: 'auto' (best mode for the model).
     prompt,
     messages,
     maxRetries: maxRetriesArg,
+    retryStrategy,
     abortSignal,
     headers,
     experimental_repairText: repairText,
@@ -249,7 +256,10 @@ Default and recommended: 'auto' (best mode for the model).
     enumValues,
   });
 
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
 
   const outputStrategy = getOutputStrategy({
     output,

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -27,6 +27,7 @@ import { createStitchableStream } from '../../src/util/create-stitchable-stream'
 import { DelayedPromise } from '../../src/util/delayed-promise';
 import { now as originalNow } from '../../src/util/now';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
@@ -234,6 +235,11 @@ Optional telemetry configuration (experimental).
       experimental_telemetry?: TelemetrySettings;
 
       /**
+Optional retry strategy configuration.
+       */
+      retryStrategy?: RetryStrategy;
+
+      /**
 Additional provider-specific options. They are passed through
 to the provider from the AI SDK and enable provider-specific
 functionality that can be fully encapsulated in the provider.
@@ -281,6 +287,7 @@ Callback that is called when the LLM response and the final object validation ar
     prompt,
     messages,
     maxRetries,
+    retryStrategy,
     abortSignal,
     headers,
     experimental_telemetry: telemetry,
@@ -326,6 +333,7 @@ Callback that is called when the LLM response and the final object validation ar
     headers,
     settings,
     maxRetries,
+    retryStrategy,
     abortSignal,
     outputStrategy,
     system,
@@ -370,6 +378,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     telemetry,
     settings,
     maxRetries: maxRetriesArg,
+    retryStrategy,
     abortSignal,
     outputStrategy,
     system,
@@ -389,6 +398,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
     headers: Record<string, string | undefined> | undefined;
     settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
     maxRetries: number | undefined;
+    retryStrategy: RetryStrategy | undefined;
     abortSignal: AbortSignal | undefined;
     outputStrategy: OutputStrategy<PARTIAL, RESULT, ELEMENT_STREAM>;
     system: Prompt['system'];
@@ -407,6 +417,7 @@ class DefaultStreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM>
 
     const { maxRetries, retry } = prepareRetries({
       maxRetries: maxRetriesArg,
+      retryStrategy,
     });
 
     const callSettings = prepareCallSettings(settings);

--- a/packages/ai/src/generate-speech/generate-speech.ts
+++ b/packages/ai/src/generate-speech/generate-speech.ts
@@ -5,6 +5,7 @@ import {
   detectMediaType,
 } from '../../src/util/detect-media-type';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { SpeechWarning } from '../types/speech-model';
 import { SpeechModelResponseMetadata } from '../types/speech-model-response-metadata';
 import { SpeechResult } from './generate-speech-result';
@@ -41,6 +42,7 @@ export async function generateSpeech({
   language,
   providerOptions = {},
   maxRetries: maxRetriesArg,
+  retryStrategy,
   abortSignal,
   headers,
 }: {
@@ -102,6 +104,11 @@ Maximum number of retries per speech model call. Set to 0 to disable retries.
   maxRetries?: number;
 
   /**
+Optional retry strategy configuration.
+   */
+  retryStrategy?: RetryStrategy;
+
+  /**
 Abort signal.
  */
   abortSignal?: AbortSignal;
@@ -112,7 +119,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<SpeechResult> {
-  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
 
   const result = await retry(() =>
     model.doGenerate({

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -1,4 +1,5 @@
 import {
+  APICallError,
   LanguageModelV2CallOptions,
   LanguageModelV2FunctionTool,
   LanguageModelV2Prompt,
@@ -2706,10 +2707,13 @@ describe('generateText', () => {
         doGenerate: async () => {
           callCount++;
           if (callCount === 1) {
-            throw {
+            throw new APICallError({
               message: 'simulated error',
+              url: 'test-url',
+              requestBodyValues: {},
               isRetryable: true,
-            };
+              data: undefined,
+            });
           }
           return {
             ...dummyResponseValues,
@@ -2740,10 +2744,13 @@ describe('generateText', () => {
         doGenerate: async () => {
           callCount++;
           if (callCount === 1) {
-            throw {
+            throw new APICallError({
               message: 'simulated error',
+              url: 'test-url',
+              requestBodyValues: {},
               isRetryable: true,
-            };
+              data: undefined,
+            });
           }
           return {
             ...dummyResponseValues,
@@ -2775,13 +2782,16 @@ describe('generateText', () => {
         doGenerate: async () => {
           callCount++;
           if (callCount === 1) {
-            throw {
+            throw new APICallError({
               message: 'rate limit error',
+              url: 'test-url',
+              requestBodyValues: {},
               isRetryable: true,
+              data: undefined,
               responseHeaders: {
                 'retry-after': '10', // 10 seconds - should be ignored
               },
-            };
+            });
           }
           return {
             ...dummyResponseValues,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -12,6 +12,7 @@ import { Tracer } from '@opentelemetry/api';
 import { NoOutputSpecifiedError } from '../../src/error/no-output-specified-error';
 import { asArray } from '../../src/util/as-array';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { ModelMessage } from '../prompt';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -122,6 +123,7 @@ export async function generateText<
   prompt,
   messages,
   maxRetries: maxRetriesArg,
+  retryStrategy,
   abortSignal,
   headers,
   stopWhen = stepCountIs(1),
@@ -165,6 +167,11 @@ When the condition is an array, any of the conditions can be met to stop the gen
     stopWhen?:
       | StopCondition<NoInfer<TOOLS>>
       | Array<StopCondition<NoInfer<TOOLS>>>;
+
+    /**
+Optional retry strategy configuration.
+     */
+    retryStrategy?: RetryStrategy;
 
     /**
 Optional telemetry configuration (experimental).
@@ -224,7 +231,10 @@ A function that attempts to repair a tool call that failed to parse.
   }): Promise<GenerateTextResult<TOOLS, OUTPUT>> {
   const model = resolveLanguageModel(modelArg);
   const stopConditions = asArray(stopWhen);
-  const { maxRetries, retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
 
   const callSettings = prepareCallSettings(settings);
 

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -37,6 +37,7 @@ import { createStitchableStream } from '../../src/util/create-stitchable-stream'
 import { DelayedPromise } from '../../src/util/delayed-promise';
 import { now as originalNow } from '../../src/util/now';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { CallSettings } from '../prompt/call-settings';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
 import { prepareCallSettings } from '../prompt/prepare-call-settings';
@@ -222,6 +223,7 @@ export function streamText<
   prompt,
   messages,
   maxRetries,
+  retryStrategy,
   abortSignal,
   headers,
   stopWhen = stepCountIs(1),
@@ -272,6 +274,11 @@ When the condition is an array, any of the conditions can be met to stop the gen
     stopWhen?:
       | StopCondition<NoInfer<TOOLS>>
       | Array<StopCondition<NoInfer<TOOLS>>>;
+
+    /**
+Optional retry strategy configuration.
+     */
+    retryStrategy?: RetryStrategy;
 
     /**
 Optional telemetry configuration (experimental).
@@ -914,6 +921,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
 
     const { maxRetries, retry } = prepareRetries({
       maxRetries: maxRetriesArg,
+      retryStrategy,
     });
 
     const tracer = getTracer(telemetry);

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -550,6 +550,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     headers,
     settings,
     maxRetries: maxRetriesArg,
+    retryStrategy,
     abortSignal,
     system,
     prompt,
@@ -577,6 +578,7 @@ class DefaultStreamTextResult<TOOLS extends ToolSet, OUTPUT, PARTIAL_OUTPUT>
     headers: Record<string, string | undefined> | undefined;
     settings: Omit<CallSettings, 'abortSignal' | 'headers'>;
     maxRetries: number | undefined;
+    retryStrategy: RetryStrategy | undefined;
     abortSignal: AbortSignal | undefined;
     system: Prompt['system'];
     prompt: Prompt['prompt'];

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -384,6 +384,7 @@ Internal. For test use only. May change without notice.
     headers,
     settings,
     maxRetries,
+    retryStrategy,
     abortSignal,
     system,
     prompt,

--- a/packages/ai/src/transcribe/transcribe.ts
+++ b/packages/ai/src/transcribe/transcribe.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src/util/detect-media-type';
 import { download } from '../../src/util/download';
 import { prepareRetries } from '../../src/util/prepare-retries';
+import { RetryStrategy } from '../../src/util/retry-with-exponential-backoff';
 import { DataContent } from '../prompt';
 import { convertDataContentToUint8Array } from '../prompt/data-content';
 import { TranscriptionWarning } from '../types/transcription-model';
@@ -31,6 +32,7 @@ export async function transcribe({
   audio,
   providerOptions = {},
   maxRetries: maxRetriesArg,
+  retryStrategy,
   abortSignal,
   headers,
 }: {
@@ -68,6 +70,11 @@ Maximum number of retries per transcript model call. Set to 0 to disable retries
   maxRetries?: number;
 
   /**
+Optional retry strategy configuration.
+   */
+  retryStrategy?: RetryStrategy;
+
+  /**
 Abort signal.
  */
   abortSignal?: AbortSignal;
@@ -78,7 +85,10 @@ Only applicable for HTTP-based providers.
  */
   headers?: Record<string, string>;
 }): Promise<TranscriptionResult> {
-  const { retry } = prepareRetries({ maxRetries: maxRetriesArg });
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    retryStrategy,
+  });
   const audioData =
     audio instanceof URL
       ? (await download({ url: audio })).data

--- a/packages/ai/src/util/index.ts
+++ b/packages/ai/src/util/index.ts
@@ -4,5 +4,6 @@ export type { DeepPartial } from './deep-partial';
 export { type ErrorHandler } from './error-handler';
 export { isDeepEqualData } from './is-deep-equal-data';
 export { parsePartialJson } from './parse-partial-json';
+export type { RetryStrategy } from './retry-with-exponential-backoff';
 export { SerialJobExecutor } from './serial-job-executor';
 export { simulateReadableStream } from './simulate-readable-stream';

--- a/packages/ai/src/util/prepare-retries.ts
+++ b/packages/ai/src/util/prepare-retries.ts
@@ -1,6 +1,7 @@
 import { InvalidArgumentError } from '../../src/error/invalid-argument-error';
 import {
   RetryFunction,
+  RetryStrategy,
   retryWithExponentialBackoff,
 } from '../../src/util/retry-with-exponential-backoff';
 
@@ -9,8 +10,10 @@ import {
  */
 export function prepareRetries({
   maxRetries,
+  retryStrategy,
 }: {
   maxRetries: number | undefined;
+  retryStrategy?: RetryStrategy;
 }): {
   maxRetries: number;
   retry: RetryFunction;
@@ -37,6 +40,9 @@ export function prepareRetries({
 
   return {
     maxRetries: maxRetriesResult,
-    retry: retryWithExponentialBackoff({ maxRetries: maxRetriesResult }),
+    retry: retryWithExponentialBackoff({
+      maxRetries: maxRetriesResult,
+      retryStrategy,
+    }),
   };
 }

--- a/packages/ai/src/util/retry-with-exponential-backoff.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.ts
@@ -172,7 +172,7 @@ async function _retryWithExponentialBackoff<OUTPUT>(
         {
           maxRetries,
           delayInMs: nextDelay,
-          backoffFactor,
+          backoffFactor: configuredBackoffFactor,
           retryStrategy,
         },
         newErrors,


### PR DESCRIPTION
## Summary
- Adds `retryStrategy` parameter to all generate functions while keeping `maxRetries` at top level
- Builds upon the existing rate limit header respecting logic from the base branch

## Changes
- **Added `RetryStrategy` interface** with configuration parameters:
  - `initialDelayInMs` - Starting delay (default: 2000ms)
  - `backoffFactor` - Multiplier for exponential backoff (default: 2)
  - `maxDelayInMs` - Maximum delay cap (default: no limit)
  - `jitter` - Whether to add 10% random jitter (default: false)
  - `respectRateLimitHeaders` - Whether to respect rate limit headers (default: true)
- **Updated retry logic** to support configurable retry strategies while maintaining backward compatibility
- **Added `retryStrategy` parameter** to all SDK functions:
  - `generateText` / `streamText`
  - `generateObject` / `streamObject`
  - `embed` / `embedMany`
  - `generateImage`
  - `generateSpeech`
  - `transcribe`
- **Added comprehensive tests** for custom retry strategies
- **Exported `RetryStrategy` type** from util exports

## Usage Examples

### Custom retry configuration with jitter
```typescript
const result = await generateText({
  model: openai('gpt-4o'),
  prompt: 'Hello',
  maxRetries: 5,
  retryStrategy: {
    initialDelayInMs: 500,     // Start with 500ms delay
    backoffFactor: 3,          // Triple the delay each retry
    maxDelayInMs: 30000,       // Cap at 30 seconds
    jitter: true,              // Add 10% random jitter
    respectRateLimitHeaders: true, // Still respect rate limit headers
  },
});
```

### Disable rate limit header respect for testing
```typescript
const result = await generateText({
  model: openai('gpt-4o'),
  prompt: 'Test prompt',
  maxRetries: 3,
  retryStrategy: {
    respectRateLimitHeaders: false,
    initialDelayInMs: 100,     // Fast retries for testing
  },
});
```

### Linear backoff instead of exponential
```typescript
const result = await generateText({
  model: anthropic('claude-3-opus'),
  prompt: 'Analyze this...',
  maxRetries: 10,
  retryStrategy: {
    initialDelayInMs: 2000,
    backoffFactor: 1,          // Linear: 2s, 2s, 2s...
  },
});
```

### Aggressive retries with cap
```typescript
const result = await generateText({
  model: openai('gpt-4o'),
  prompt: 'Critical operation',
  maxRetries: 10,
  retryStrategy: {
    initialDelayInMs: 100,
    backoffFactor: 2,
    maxDelayInMs: 5000,        // Never wait more than 5s
    jitter: true,
  },
});
```

## Test Plan
- [x] Added unit tests for custom retry configurations
- [x] Added tests for jitter functionality
- [x] Added tests for max delay cap
- [x] Added tests for `respectRateLimitHeaders` flag behavior
- [x] Added integration tests in `generate-text.test.ts`
- [x] Verified backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)